### PR TITLE
Linux context match

### DIFF
--- a/apps/neovim.py
+++ b/apps/neovim.py
@@ -23,6 +23,10 @@ and app.exe: conhost.exe
 
 os: windows
 and app.exe: nvim-qt.exe
+
+os: linux
+and win.title: /VIM MODE/
+and win.title: /nvim/
 """
 
 ctx.matches = r"""


### PR DESCRIPTION
Adds a talon context match to match on the window title to signify nvim

Wasn't clear if I should be merging this into beta or main. The main branch works fine for me locally and when we were testing it was fine, but I am realizing the readme says I should be using beta. 