### PR TITLE
Add MacOS neovim app activation

### DIFF
--- a/apps/neovim.py
+++ b/apps/neovim.py
@@ -27,6 +27,9 @@ and app.exe: nvim-qt.exe
 os: linux
 and win.title: /VIM MODE/
 and win.title: /nvim/
+
+os: mac
+and win.title: /nvim/
 """
 
 ctx.matches = r"""

--- a/apps/neovim.py
+++ b/apps/neovim.py
@@ -29,6 +29,7 @@ and win.title: /VIM MODE/
 and win.title: /nvim/
 
 os: mac
+and win.title: /VIM MODE/
 and win.title: /nvim/
 """
 


### PR DESCRIPTION
This might be a looser matcher than we want, but works for me. Worth reviewing to ensure it's not too loose. In particular the other matchers seem to require `VIM MODE`, but that didn't appear in my window title 🤔