### PR TITLE
fix: generally call the run_command instead of run_normal to avoid paste() problem

### DIFF
--- a/core/vim_non_command.talon
+++ b/core/vim_non_command.talon
@@ -6,4 +6,4 @@ and not tag: user.vim_mode_command
 go term:
     user.vim_set_terminal()
 new term:
-    user.vim_run_normal_exterm(":term\n")
+    user.vim_run_command_exterm(":term\n")


### PR DESCRIPTION
see #21