### PR TITLE
feat: working plugin scope for nixvim and lazy

### DIFF
--- a/core/plugins/lazy/lazy.py
+++ b/core/plugins/lazy/lazy.py
@@ -3,16 +3,17 @@ from talon import Module, Context, actions
 mod = Module()
 
 # when lazy main menu is not shown
-ctx_off = Context()
-ctx_off.matches = r"""
-app: neovim
+ctx_global = Context()
+ctx_global.matches = r"""
+user.neovim_plugin: lazy
 and not win.title: /FILETYPE:\[lazy\]/
+
 """
 
 # when lazy main menu is shown
-ctx_on = Context()
-ctx_on.matches = r"""
-app: neovim
+ctx_open = Context()
+ctx_open.matches = r"""
+user.neovim_plugin: lazy
 and win.title: /FILETYPE:\[lazy\]/
 """
 
@@ -63,8 +64,8 @@ class Actions:
         """close lazy home menu"""
 
 
-@ctx_off.action_class("user")
-class Actions:
+@ctx_global.action_class("user")
+class LazyGlobalActions:
     def lazy_home():
         actions.user.vim_run_command_exterm(":Lazy home\n")
 
@@ -107,8 +108,8 @@ class Actions:
     # def lazy_close():
 
 
-@ctx_on.action_class("user")
-class Actions:
+@ctx_open.action_class("user")
+class LazyMenuActions:
     def lazy_home():
         actions.user.vim_run_normal("H")
 

--- a/core/plugins/lazy/lazy.talon
+++ b/core/plugins/lazy/lazy.talon
@@ -1,18 +1,18 @@
-app: neovim
+# https://github.com/folke/lazy.nvim
+user.neovim_plugin: lazy
 -
 
-# requires: https://github.com/folke/lazy.nvim
-lazy (open | home):     user.lazy_home()
-lazy install:           user.lazy_install()
-lazy update:            user.lazy_update()
-lazy sync:              user.lazy_sync()
-lazy clean:             user.lazy_clean()
-lazy clear:             user.lazy_clear()
-lazy check:             user.lazy_check()
-lazy log:               user.lazy_log()
-lazy restore:           user.lazy_restore()
-lazy profile:           user.lazy_profile()
-lazy debug:             user.lazy_debug()
-lazy help:              user.lazy_help()
-lazy health:            user.lazy_health()
-lazy (close | quit):    user.lazy_close()
+lazy (open | home):         user.lazy_home()
+lazy install:               user.lazy_install()
+lazy update:                user.lazy_update()
+lazy sync:                  user.lazy_sync()
+lazy clean:                 user.lazy_clean()
+lazy clear:                 user.lazy_clear()
+lazy check:                 user.lazy_check()
+lazy log:                   user.lazy_log()
+lazy restore:               user.lazy_restore()
+lazy profile:               user.lazy_profile()
+lazy debug:                 user.lazy_debug()
+lazy help:                  user.lazy_help()
+lazy health:                user.lazy_health()
+lazy (close | quit):        user.lazy_close()

--- a/core/plugins/plugins.py
+++ b/core/plugins/plugins.py
@@ -53,6 +53,8 @@ def _lazyvim_plugin_list(rpc: NeoVimRPC) -> list[str]:
             name = plugin.split("/")[1]
             if name.endswith(".nvim"):
                 name = name[:-5]
+            if name.endswith(".vim"):
+                name = name[:-4]
             plugins.append(name)
     except pynvim.api.NvimError as e:
         print(e)
@@ -104,8 +106,8 @@ def neovim_update_plugin_list() -> list[str]:
         return []
 
     plugin_manager_funcs = [
-        _nixvim_plugin_list,
         _lazyvim_plugin_list,
+        _nixvim_plugin_list,
         _vundle_plugin_list,
         _vim_plug_plugin_list,
         _packer_plugin_list,

--- a/core/plugins/plugins.py
+++ b/core/plugins/plugins.py
@@ -1,0 +1,148 @@
+import pathlib
+import pynvim
+
+from talon import Context, Module, actions, app, settings, ui, registry
+from ..rpc.rpc import NeoVimRPC
+
+mod = Module()
+
+
+@mod.scope
+def scope():
+    return {"neovim_plugin": neovim_plugin_list()}
+
+
+# Cached list of plugins. Refreshable by calling voice command
+neovim_plugin_cache = None
+
+
+def _nixvim_plugin_list(rpc: NeoVimRPC) -> list[str]:
+    """Pulls the list of plugins used by nixvim out of the nix store
+
+    nixvim sets up a custom pack dir called myNeovimPackages"""
+
+    runtimepath = rpc.nvim.command_output(":set runtimepath")
+    # We get back a string like:
+    # runtimepath=<path>,<path>,<path>
+    paths = runtimepath.split("=")[1].split(",")
+    plugins = []
+    for path in paths:
+        if path.startswith("/nix/store") and path.endswith("vim-pack-dir"):
+            pack_dir = pathlib.Path(path) / "pack" / "myNeovimPackages"
+            plugins = [p.stem for p in pack_dir.rglob("*") if p.is_symlink()]
+    return plugins
+
+
+def _lazyvim_plugin_list(rpc: NeoVimRPC) -> list[str]:
+    """Pulls the list of plugins used by lazyvim plugin manager"""
+    plugins = []
+    try:
+        # Returns a list of tables like { { "name0", _ = ... }, { "name1", _ = ... }, ...}
+        lua = """
+        local plugins = require('lazy').plugins()
+        local names = {}
+        for _, plugin in ipairs(plugins) do
+            table.insert(names, plugin[1])
+        end
+        return names
+        """
+        plugin_list = rpc.nvim.exec_lua(lua)
+        # Returns a list of strings like:
+        # ['folke/lazy.nvim', 'nvim-lua/plenary.nvim', 'nvim-telescope/telescope.nvim']
+        for plugin in plugin_list:
+            name = plugin.split("/")[1]
+            if name.endswith(".nvim"):
+                name = name[:-5]
+            plugins.append(name)
+    except pynvim.api.NvimError as e:
+        print(e)
+        return plugins
+    return plugins
+
+
+def _vundle_plugin_list(rpc: NeoVimRPC) -> list[str]:
+    """Pulls the list of plugins used by Vundle plugin manager"""
+    plugins = []
+    try:
+        plugin_list = rpc.nvim.command_output(":PluginList")
+    except pynvim.api.NvimError:
+        return plugins
+    # FIXME: parse output
+    app.notify("ERROR: Vundle plugin list not implemented. File an issue on GitHub.")
+    return plugins
+
+
+def _vim_plug_plugin_list(rpc: NeoVimRPC) -> list[str]:
+    """Pulls the list of plugins used by vim-plug plugin manager"""
+    plugins = []
+    try:
+        plugin_list = rpc.nvim.command_output(":PlugStatus")
+    except pynvim.api.NvimError:
+        return plugins
+    # FIXME: parse output
+    app.notify("ERROR: vim-plug plugin list not implemented. File an issue on GitHub.")
+    return plugins
+
+
+def _packer_plugin_list(rpc: NeoVimRPC) -> list[str]:
+    """Pulls the list of plugins used by packer plugin manager"""
+    plugins = []
+    plugin_list = rpc.nvim.command_output(":lua print(vim.g.packer_plugins)")
+    if plugin_list == "nil":
+        return plugins
+    # FIXME: parse output
+    app.notify("ERROR: packer plugin list not implemented. File an issue on GitHub.")
+    return plugins
+
+
+def neovim_update_plugin_list() -> list[str]:
+    """Uses neovim RPC to get the list of plugins"""
+    if "neovim" not in registry.active_apps():
+        return []
+    rpc = NeoVimRPC()
+    if rpc.init_ok is False:
+        return []
+
+    plugin_manager_funcs = [
+        _nixvim_plugin_list,
+        _lazyvim_plugin_list,
+        _vundle_plugin_list,
+        _vim_plug_plugin_list,
+        _packer_plugin_list,
+    ]
+
+    for func in plugin_manager_funcs:
+        result = func(rpc)
+        if len(result) > 0:
+            return result
+
+    return []
+
+
+def neovim_plugin_list() -> set[str] | None:
+    """Returns a cached or new list of installed neovim plugins"""
+    if "neovim" not in registry.active_apps():
+        return None
+    global neovim_plugin_cache
+    if neovim_plugin_cache is None:
+        neovim_plugin_cache = neovim_update_plugin_list()
+    return set(neovim_plugin_cache)
+
+
+@mod.action_class
+class PluginActions:
+    def neovim_plugin_list_refresh():
+        """Refresh the cached list of installed neovim plugins"""
+        global neovim_plugin_cache
+        neovim_plugin_cache = neovim_update_plugin_list()
+        scope.update()
+
+    def neovim_plugin_list_print():
+        """Print the list of installed neovim plugins"""
+        if neovim_plugin_cache is None:
+            actions.user.neovim_plugin_list_refresh()
+        print(neovim_plugin_cache)
+
+
+ui.register("win_focus", scope.update)
+ui.register("win_title", scope.update)

--- a/core/plugins/plugins.talon
+++ b/core/plugins/plugins.talon
@@ -1,0 +1,5 @@
+app: neovim
+-
+
+neovim plugin refresh:      user.neovim_plugin_list_refresh()
+neovim plugin print:        user.neovim_plugin_list_print()

--- a/core/plugins/taboo/taboo.py
+++ b/core/plugins/taboo/taboo.py
@@ -1,0 +1,21 @@
+# https://github.com/gcmt/taboo.vim
+from talon import Context, Module, actions
+
+mod = Module()
+ctx = Context()
+ctx.matches = r"""
+user.neovim_plugin: taboo
+and not tag: user.vim_mode_command
+"""
+
+
+@ctx.action_class("user")
+class TabActions:
+    def tab_rename(name: str):
+        actions.user.vim_run_normal_exterm(f":TabooRename {name}")
+
+    def tab_new_named(name: str = ""):
+        actions.user.vim_run_command_exterm(f":TabooOpen {name}")
+
+    def tab_reset():
+        actions.user.vim_run_command_exterm(":TabooReset")

--- a/core/plugins/taboo/taboo.py
+++ b/core/plugins/taboo/taboo.py
@@ -11,11 +11,24 @@ and not tag: user.vim_mode_command
 
 @ctx.action_class("user")
 class TabActions:
-    def tab_rename(name: str):
-        actions.user.vim_run_normal_exterm(f":TabooRename {name}")
+    def tab_rename(name: str = ""):
+        actions.user.vim_run_command_exterm(f":TabooRename {name}")
 
-    def tab_new_named(name: str = ""):
+    def tab_open_with_name(name: str = ""):
         actions.user.vim_run_command_exterm(f":TabooOpen {name}")
 
-    def tab_reset():
+    def tab_name_reset():
         actions.user.vim_run_command_exterm(":TabooReset")
+
+
+# FIXME: TEMPORARY: Once https://github.com/talonhub/community/pull/1446 is merged, this should be removed
+@mod.action_class
+class Actions:
+    def tab_rename(name: str = ""):
+        """Renames the current tab"""
+
+    def tab_open_with_name(name: str = ""):
+        """Opens a new tab and rename it"""
+
+    def tab_name_reset():
+        """Resets the name of the current tab"""

--- a/core/plugins/vim-zoom/vim-zoom.py
+++ b/core/plugins/vim-zoom/vim-zoom.py
@@ -1,0 +1,15 @@
+# https://github.com/dhruvasagar/vim-zoom
+from talon import Context, Module, actions
+
+mod = Module()
+ctx = Context()
+ctx.matches = r"""
+user.neovim_plugin: vim-zoom
+and not tag: user.vim_mode_command
+"""
+
+
+@ctx.action_class("user")
+class SplitActions:
+    def split_toggle_maximize():
+        actions.user.vim_run_normal("\\<c-w>m")

--- a/core/split/split.py
+++ b/core/split/split.py
@@ -98,10 +98,6 @@ class UserActions:
         actions.key("ctrl-w")
         actions.key("o")
 
-    # Requirement: https://github.com/dhruvasagar/vim-zoom
-    def split_layout_toggle_maximize():
-        actions.user.vim_run_normal_exterm_key("ctrl-w m")
-
 
 @mod.action_class
 class SplitActions:

--- a/core/tabs/tabs.talon
+++ b/core/tabs/tabs.talon
@@ -1,3 +1,9 @@
 app: neovim
 tag: user.tabs
 -
+
+# FIXME: TEMPORARY: Once https://github.com/talonhub/community/pull/1446 is merged, this should be removed
+# requires: https://github.com/gcmt/taboo.vim/
+tab (open | new) named [<user.text>]: user.tab_open_with_name(text or "")
+tab rename [<user.text>]: user.tab_rename(text or "")
+tab [name] reset: user.tab_name_reset()


### PR DESCRIPTION
This fixes #12 and invalidates PR #11 as I updated the context match, and also updated the action names to match #5 naming.

I've tested it on both nixvim and with lazy.nvim. I've put skeletons in for a few other common package managers, but haven't implemented them yet as it's not a priority. I'll file an issue to do it later.

Not sure what the difference is between our talonfmt config in vscode that caused the lazy.talon whitespace changes, but I can remove that hunk if you find it annoying.