### PR TITLE
Fail gracefully when pynvim import fails

### DIFF
--- a/core/plugins/plugins.py
+++ b/core/plugins/plugins.py
@@ -1,7 +1,14 @@
 import pathlib
-import pynvim
-
 from talon import Context, Module, actions, app, settings, ui, registry
+
+# TODO: make sure pynvim is installed in talon python environment
+try:
+    import pynvim
+except:
+    app.notify(
+        "Please install pynvim in the talon python environment for neovim support"
+    )
+
 from ..rpc.rpc import NeoVimRPC
 
 mod = Module()

--- a/core/rpc/rpc.py
+++ b/core/rpc/rpc.py
@@ -1,11 +1,16 @@
+import logging
+
 from talon import Context, Module, actions, app, settings, ui
 
 from .direct_input import VimDirectInput
 
-import logging
-
 # TODO: make sure pynvim is installed in talon python environment
-import pynvim
+try:
+    import pynvim
+except:
+    app.notify(
+        "Please install pynvim in the talon python environment for neovim support"
+    )
 
 
 class VimRPC:


### PR DESCRIPTION
Workaround for #1 

The pop-ups on every start might be annoying, but at least stops things from completely breaking if you just want these user file sets in order to use cursorless

Happy for a better solution, but I think we need at least something if we're going to call cursorless-neovim a working POC