### PR TITLE
fix(rpc): Improve missing pynvim exception handling

### DIFF
--- a/core/rpc/rpc.py
+++ b/core/rpc/rpc.py
@@ -92,7 +92,12 @@ class NeoVimRPC:
 
                 # NOTE: This is used to avoid "Using selector: EpollSelector" spam
                 self.nvim = pynvim.attach("socket", path=self.rpc_path)
+<<<<<<< Updated upstream
             except RuntimeError:
+=======
+            except (NameError, RuntimeError) as e:
+                print(e)
+>>>>>>> Stashed changes
                 return
             self.init_ok = True
         else:


### PR DESCRIPTION
I noticed while running on mac testing something else that it wasn't handling all missing pynvim cases, which broke other things. There could be others, but I didn't hunt yet.