### PR TITLE
Use normal! to do normal actions via rpc

### DIFF
--- a/core/rpc/rpc.py
+++ b/core/rpc/rpc.py
@@ -66,7 +66,7 @@ class VimRPC:
 
     def run_normal_mode_command(self, cmd):
         cmd = cmd.replace('"', r"\"")
-        self.nvrpc.nvim.command(f':exe "normal" "{cmd}"', async_=True)
+        self.nvrpc.nvim.command(f':exe "normal!" "{cmd}"', async_=True)
 
 
 class NeoVimRPC:


### PR DESCRIPTION
Add the bang so that user mappings are ignored when sending normal commands. This makes neovim-talon behavior more robust to a range of user mappings.

For example, if someone has some mapping like gg to `:echo "good game; get good"` instead of "go to top of file", our `select all` command will no longer print that to the console, but instead will send the default behaviour of `ggVG`.